### PR TITLE
Add OpenMPI 5.0.7 with GCC 15.1.0

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.7-GCC-15.1.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.7-GCC-15.1.0.eb
@@ -1,0 +1,43 @@
+name = 'OpenMPI'
+version = '5.0.7'
+
+homepage = 'https://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-3 implementation."""
+
+toolchain = {'name': 'GCC', 'version': '15.1.0'}
+
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+sources = [SOURCELOWER_TAR_BZ2]
+patches = [
+    ('OpenMPI-5.0.6_build-with-internal-cuda-header.patch', 1),
+    ('OpenMPI-5.0.7_fix-sshmem-build-failure.patch'),
+]
+checksums = [
+    {'openmpi-5.0.7.tar.bz2': '119f2009936a403334d0df3c0d74d5595a32d99497f9b1d41e90019fee2fc2dd'},
+    {'OpenMPI-5.0.6_build-with-internal-cuda-header.patch':
+     '4821f0740ae4b97f3ff5259f7bac67a11d8cdeede3b1425825c241cf6a2864bb'},
+    {'OpenMPI-5.0.7_fix-sshmem-build-failure.patch':
+     '7382a5bbe44c6eff9ab05c8f315a8911d529749655126d4375e44e809bfedec7'},
+]
+
+builddependencies = [
+    ('pkgconf', '2.3.0'),
+    ('Autotools', '20240712'),
+]
+
+dependencies = [
+    ('zlib', '1.3.1'),
+    ('hwloc', '2.11.2'),
+    ('libevent', '2.1.12'),
+    ('UCX', '1.18.0'),
+    ('libfabric', '2.0.0'),
+    ('PMIx', '5.0.6'),
+    ('PRRTE', '3.0.8'),
+    ('UCC', '1.3.0'),
+]
+
+# CUDA related patches and custom configure option can be removed if CUDA support isn't wanted.
+preconfigopts = 'gcc -Iopal/mca/cuda/include -shared opal/mca/cuda/lib/cuda.c -o opal/mca/cuda/lib/libcuda.so && '
+configopts = '--with-cuda=%(start_dir)s/opal/mca/cuda --with-show-load-errors=no '
+
+moduleclass = 'mpi'


### PR DESCRIPTION
This commit introduces a new EasyConfig file for OpenMPI version 5.0.7, compiled with GCC version 15.1.0.

The new EasyConfig file is based on the existing one for OpenMPI 5.0.7 with GCC 14.2.0.
The GCC toolchain version has been updated to 15.1.0. Dependencies and build dependencies were reviewed and kept at their existing versions, as they are the latest available and presumed compatible. Checksums and patches from the GCC 14.2.0 based EasyConfig have been retained as they are expected to remain valid and necessary.